### PR TITLE
Addition to third-party licenses txt

### DIFF
--- a/LICENSE-3rd-party.txt
+++ b/LICENSE-3rd-party.txt
@@ -70,6 +70,7 @@ Packages under the MIT License:
   - prettier-plugin-tailwindcss         @ ^0.2.5
   - tailwindcss                       @ ^3.3.3
   - vitest                            @ ^0.29.7
+  - next-runtime-env                  @ ^1.3.0
 
 Full MIT License Text:
 --------------------------------------------------


### PR DESCRIPTION
W.r.t. commit ID cd537b88bfe45c7b7bc5f845d7489978a762aae6: Added next-runtime-env package version 1.3.0 to the list of third-party licenses.