### PR TITLE
Add Docker Compose Support for UI + Backend Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,31 +33,25 @@ git clone git@github.com:NVIDIA/AIQToolkit.git
 cd AIQToolkit
 ```
 
+### Running the Application
+
+#### Local Development
+
 Install dependencies:
+
 ```bash
 npm ci
 ```
 
-### Running the Application
-
-#### Local Development
 ```bash
 npm run dev
 ```
 The application will be available at `http://localhost:3000`
 
-#### Docker Deployment
-```bash
-# Build the Docker image
-docker build -t AIQ Toolkit-UI .
-
-# Run the container with environment variables from .env
-# Ensure the .env file is present before running this command.
-# Skip --env-file .env if no overrides are needed.
-docker run --env-file .env -p 3000:3000 AIQ Toolkit-UI
-```
-
 ![AIQ Toolkit Web User Interface](public/screenshots/ui_home_page.png)
+
+#### Docker Deployment
+Please see [Usage Examples](#usage-examples) for Docker deployment examples with complete server setups.
 
 ## Configuration
 
@@ -82,12 +76,66 @@ NOTE: Most of the time, you will want to select /chat/stream for intermediate re
 
 ### Simple Calculator Example
 
-#### Setup and Configuration
-1. Set up [AIQ Toolkit Get Started ](https://github.com/NVIDIA/AIQToolkit/blob/main/docs/source/intro/get-started.md)
-2. Start workflow by following the [Simple Calculator Example](https://github.com/NVIDIA/AIQToolkit/blob/main/examples/simple_calculator/README.md)
+#### Option 1: Docker Compose (Recommended)
+For a complete setup with the UI, calculator server, and Phoenix Telemetry:
+
 ```bash
-aiq serve --config_file=examples/simple_calculator/configs/config.yml
+# Make sure you're logged into NVIDIA's container registry
+# The NeMo-Agent-Toolkit calculator server requires this to build image. 
+docker login nvcr.io
+# Username: $oauthtoken
+# Password: <your-nvidia-api-key>
+
+# Make sure you have your NVIDIA API key set
+export NVIDIA_API_KEY=your_api_key_here
+
+docker compose -f compose_calculator.yaml up -d
 ```
+
+That's it! This will start:
+- **UI** on `http://localhost:3000`
+- **Calculator Server** on `http://localhost:8000` (with API docs at `/docs`)
+- **Phoenix Telemetry** on `http://localhost:6006`
+
+
+To check containers and logs:
+
+```bash
+docker ps -a
+docker logs aiq-ui
+```
+
+To stop the services:
+```bash
+docker compose -f compose_calculator.yaml down
+```
+
+#### Option 2: Manual Setup (Requires External Server)
+
+1. Set up [AIQ Toolkit Get Started ](https://github.com/NVIDIA/AIQToolkit/blob/main/docs/source/intro/get-started.md)
+2. Start the calculator server by following the [Simple Calculator Example](https://github.com/NVIDIA/AIQToolkit/blob/main/examples/simple_calculator/README.md)
+```bash
+aiq serve --config_file=examples/basic/functions/simple_calculator/configs/config.yml
+```
+3. Start the UI using one of these approaches:
+
+**Local UI:**
+```bash
+npm run dev
+```
+
+**Docker UI:**
+```bash
+# Build the Docker image
+docker build -t aiqtoolkit-ui .
+
+# Requires --network=host to access external server
+docker run -d --name aiq-ui --network=host --env-file .env aiqtoolkit-ui
+```
+
+**Important Notes for Manual Docker Setup:**
+- ⚠️ **Security Warning**: Docker with `--network=host` gives the container access to all host network interfaces. Only use this for local development, never in production or shared environments.
+- Both UI options can access the calculator server on `localhost:8000` directly
 
 #### Testing the Calculator
 Interact with the chat interface by prompting the agent with the message:

--- a/compose_calculator.yaml
+++ b/compose_calculator.yaml
@@ -1,0 +1,51 @@
+services:
+
+# To pull the image from NVIDIA's registry, you need to log in first.
+# Make sure you have your NVIDIA API key ready.
+# docker login nvcr.io
+# When prompted:
+# Username: $oauthtoken
+# Password: <nvapi-your_actual_api_key_here>
+# The username really is $oauthtoken (no need to change), and the password is your NVIDIA API key.
+  aiq-server:
+    build:
+      context: ../NeMo-Agent-Toolkit  # Point to the sibling directory
+      dockerfile: examples/basic/functions/simple_calculator/Dockerfile
+    container_name: aiq-calculator-server
+    ports:
+      - "8000:8000"
+      - "6006:6006"  # Phoenix telemetry service
+    environment:
+      - NVIDIA_API_KEY=${NVIDIA_API_KEY}
+    networks:
+      - aiq-network
+    healthcheck:
+      test: ["CMD-SHELL", "python -c 'import urllib.request; urllib.request.urlopen(\"http://localhost:8000/docs\")' || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  aiq-ui:
+    build:
+      context: .  # Current directory (NeMo-Agent-Toolkit-UI)
+      dockerfile: Dockerfile
+    container_name: aiq-ui
+    ports:
+      - "3000:3000"
+    environment:
+      - NEXT_PUBLIC_WORKFLOW=AIQ Toolkit
+      - NEXT_PUBLIC_HTTP_CHAT_COMPLETION_URL=http://aiq-server:8000/chat/stream
+      - NEXT_PUBLIC_WEBSOCKET_CHAT_COMPLETION_URL=ws://aiq-server:8000/websocket
+      - NEXT_PUBLIC_WEB_SOCKET_DEFAULT_ON=false
+      - NEXT_PUBLIC_CHAT_HISTORY_DEFAULT_ON=false
+      - NEXT_PUBLIC_RIGHT_MENU_OPEN=false
+    networks:
+      - aiq-network
+    depends_on:
+      aiq-server:
+        condition: service_healthy
+
+networks:
+  aiq-network:
+    driver: bridge


### PR DESCRIPTION
## Overview
This PR makes Docker deployment improvements and closes Issue #23. 

## Key Changes
Added `compose_calculator.yaml` for a one-command deployment of the calculator example with:
- Pre-configured environment variables for seamless UI + calculator server connectivity
- A bridge network for secure container-to-container communication
- Added health checks to ensure proper service startup sequence
- Phoenix telemetry setup on port 6006 for monitoring and debugging

Updated README.md to:
- Add Docker Compose instructions for the simple calculator example.
- Provided instructions for starting, checking status, and stopping the services
- Maintained existing manual calculator setup instructions for users who prefer this approach

## Problem Addressed
Previously, a user might find connecting the UI container to a backend service via UI settings would not work. This is because Docker's default bridge network would have prevented the UI from accessing services running on the host's localhost.  While it is possible to use a docker run workaround (e.g. `--network=host`) to allow the UI container to access an NeMo Agent Toolkit server, this is not a production-ready approach due to security.

## Testing
- Verified end-to-end functionality with a fresh Docker Compose deployment
- Confirmed UI successfully connects to the calculator service
- Validated all health checks pass correctly
- Tested startup sequence and container dependencies
- Ensured all documented commands are accurate and copy-pasteable

