### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "AIQ Toolkit-UI",
+  "name": "aiqtoolkit-ui",
   "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "AIQ Toolkit-UI",
+      "name": "aiqtoolkit-ui",
       "version": "0.1.1",
       "dependencies": {
         "@datadog/browser-rum": "^5.11.0",


### PR DESCRIPTION
This avoids an issue for NAT users following the `docs/source/quick-start/launching-ui.md` guide resulting in changes in the git submodule.