### PR TITLE
Adding timezone info to request header

### DIFF
--- a/pages/api/chat.ts
+++ b/pages/api/chat.ts
@@ -112,7 +112,7 @@ async function processGenerateStream(response: Response, encoder: TextEncoder, d
                 if (content && typeof content === 'string') {
                   controller.enqueue(encoder.encode(content));
                 }
-              } catch {}
+              } catch { }
             } else if (
               line.includes('<intermediatestep>') &&
               line.includes('</intermediatestep>') &&
@@ -139,7 +139,7 @@ async function processGenerateStream(response: Response, encoder: TextEncoder, d
                 };
                 const msg = `<intermediatestep>${JSON.stringify(intermediateMessage)}</intermediatestep>`;
                 controller.enqueue(encoder.encode(msg));
-              } catch {}
+              } catch { }
             }
           }
         }
@@ -156,7 +156,7 @@ async function processGenerateStream(response: Response, encoder: TextEncoder, d
               controller.enqueue(encoder.encode(value.trim()));
               finalAnswerSent = true;
             }
-          } catch {}
+          } catch { }
         }
         controller.close();
         reader?.releaseLock();
@@ -198,7 +198,7 @@ async function processChatStream(response: Response, encoder: TextEncoder, decod
                 if (content) {
                   controller.enqueue(encoder.encode(content));
                 }
-              } catch {}
+              } catch { }
             } else if (
               line.startsWith('intermediate_data: ') &&
               additionalProps.enableIntermediateSteps
@@ -222,7 +222,7 @@ async function processChatStream(response: Response, encoder: TextEncoder, decod
                 };
                 const msg = `<intermediatestep>${JSON.stringify(intermediateMessage)}</intermediatestep>`;
                 controller.enqueue(encoder.encode(msg));
-              } catch {}
+              } catch { }
             }
           }
         }
@@ -255,6 +255,7 @@ const handler = async (req: Request): Promise<Response> => {
     headers: {
       'Content-Type': 'application/json',
       'Conversation-Id': req.headers.get('Conversation-Id') || '',
+      'X-Timezone': Intl.DateTimeFormat().resolvedOptions().timeZone || 'Etc/UTC',
     },
     body: JSON.stringify(payload),
   });

--- a/pages/api/chat.ts
+++ b/pages/api/chat.ts
@@ -112,7 +112,7 @@ async function processGenerateStream(response: Response, encoder: TextEncoder, d
                 if (content && typeof content === 'string') {
                   controller.enqueue(encoder.encode(content));
                 }
-              } catch { }
+              } catch {}
             } else if (
               line.includes('<intermediatestep>') &&
               line.includes('</intermediatestep>') &&
@@ -139,7 +139,7 @@ async function processGenerateStream(response: Response, encoder: TextEncoder, d
                 };
                 const msg = `<intermediatestep>${JSON.stringify(intermediateMessage)}</intermediatestep>`;
                 controller.enqueue(encoder.encode(msg));
-              } catch { }
+              } catch {}
             }
           }
         }
@@ -156,7 +156,7 @@ async function processGenerateStream(response: Response, encoder: TextEncoder, d
               controller.enqueue(encoder.encode(value.trim()));
               finalAnswerSent = true;
             }
-          } catch { }
+          } catch {}
         }
         controller.close();
         reader?.releaseLock();
@@ -198,7 +198,7 @@ async function processChatStream(response: Response, encoder: TextEncoder, decod
                 if (content) {
                   controller.enqueue(encoder.encode(content));
                 }
-              } catch { }
+              } catch {}
             } else if (
               line.startsWith('intermediate_data: ') &&
               additionalProps.enableIntermediateSteps
@@ -222,7 +222,7 @@ async function processChatStream(response: Response, encoder: TextEncoder, decod
                 };
                 const msg = `<intermediatestep>${JSON.stringify(intermediateMessage)}</intermediatestep>`;
                 controller.enqueue(encoder.encode(msg));
-              } catch { }
+              } catch {}
             }
           }
         }


### PR DESCRIPTION
## Description

Added a new header option that includes the requester's device's timezone, in IANA format. This resonates with [PR #660](https://github.com/NVIDIA/NeMo-Agent-Toolkit/pull/660) for the NAT main repo.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit-UI/blob/main/CODE-OF-CONDUCT.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
