### PR TITLE
Add features for visualizing streaming data

### DIFF
--- a/DATA_STREAMING.md
+++ b/DATA_STREAMING.md
@@ -1,0 +1,31 @@
+# Live Data Streaming
+
+The live data streaming feature allows visualization of real-time text updates across multiple streams. This is useful for monitoring ongoing processes or displaying live transcription or streaming data.
+
+## API
+
+The `/api/update-data-stream` endpoint provides functionality for managing live text streams and finalized data entries:
+
+- **POST**: Submit live text updates or finalized entries
+  - `text`: The text content to stream
+  - `stream_id`: Identifier for the data stream (defaults to 'default')
+  - `timestamp`: Unix timestamp (defaults to current time)
+  - `finalized`: Boolean flag to mark entry as finalized
+  - `uuid`: Backend UUID for database tracking
+
+- **GET**: Retrieve live or finalized data
+  - Query `?type=finalized` for processed entries
+  - Query `?stream=<stream_id>` for specific stream data
+  - No query parameters returns all live streams
+
+- **PATCH**: Update entry processing status using UUID
+
+## Data Stream Display
+
+The chat interface includes a "Data Stream Display" toggle in the header menu that enables real-time visualization of streaming data alongside chat conversations. This feature is particularly useful for monitoring live transcription feeds or processing status updates.
+
+## Database Watcher
+
+Database entries are created when data is submitted to the `/api/update-data-stream` endpoint with the `finalized` field set to `true`. These entries represent completed or processed data that should be persisted to a database system.
+
+NOTE: This API just provides visualization and does not manage a database itself. The assumption is that the user is using this API when manually updating a database.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ NOTE: Most of the time, you will want to select /chat/stream for intermediate re
   - /generate/stream - Streaming response generation
   - /chat - Single response chat completion
   - /chat/stream - Streaming chat completion
+  - /chat/ca-rag - Single response chat completion with [Context-Aware RAG](https://github.com/NVIDIA/context-aware-rag) backend
 - `WebSocket URL for Completion`: WebSocket URL to connect to running NeMo Agent Toolkit server
 - `WebSocket Schema`: Workflow schema type over WebSocket connection
 

--- a/README.md
+++ b/README.md
@@ -85,9 +85,15 @@ NOTE: Most of the time, you will want to select /chat/stream for intermediate re
   - /generate/stream - Streaming response generation
   - /chat - Single response chat completion
   - /chat/stream - Streaming chat completion
-  - /chat/ca-rag - Single response chat completion with [Context-Aware RAG](https://github.com/NVIDIA/context-aware-rag) backend
+  - /chat/ca-rag - Single response chat completion when using [Context-Aware RAG](https://github.com/NVIDIA/context-aware-rag) backend
 - `WebSocket URL for Completion`: WebSocket URL to connect to running NeMo Agent Toolkit server
 - `WebSocket Schema`: Workflow schema type over WebSocket connection
+
+### Live Data Streaming
+
+The live data streaming feature allows visualization of real-time text updates across multiple streams. This is useful for monitoring ongoing processes or displaying live transcription or streaming data.
+
+For more detail, see the [README for live data streaming](DATA_STREAMING.md).
 
 ## Usage Examples
 

--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -1,7 +1,6 @@
 
 'use client';
 
-import { ChatHeader } from './ChatHeader';
 import { ChatInput } from './ChatInput';
 import { ChatLoader } from './ChatLoader';
 import { MemoizedChatMessage } from './MemoizedChatMessage';
@@ -1344,7 +1343,6 @@ export const Chat = () => {
           ref={chatContainerRef}
           onScroll={handleScroll}
         >
-          <ChatHeader webSocketModeRef={webSocketModeRef} />
           {selectedConversation?.messages.map((message, index) => {
             if (!shouldRenderAssistantMessage(message)) {
               return null; // Hide empty assistant messages

--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -853,6 +853,7 @@ export const Chat = () => {
             : [{ role: 'user', content: message?.content }],
           chatCompletionURL:
             sessionStorage.getItem('chatCompletionURL') || chatCompletionURL,
+          conversationId: selectedConversation?.id || '',
           additionalProps: {
             enableIntermediateSteps: sessionStorage.getItem(
               'enableIntermediateSteps'

--- a/components/Chat/ChatHeader.tsx
+++ b/components/Chat/ChatHeader.tsx
@@ -36,6 +36,7 @@ export const ChatHeader = ({ webSocketModeRef = {} }) => {
       webSocketConnected,
       lightMode,
       selectedConversation,
+      showDataStreamDisplay,
     },
     dispatch: homeDispatch,
   } = useContext(HomeContext);
@@ -167,6 +168,32 @@ export const ChatHeader = ({ webSocketModeRef = {} }) => {
                 <span
                   className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform duration-300 ease-in-out ${
                     webSocketModeRef.current ? 'translate-x-6' : 'translate-x-0'
+                  }`}
+                />
+              </div>
+            </label>
+          </div>
+
+          {/* Data Stream Display Toggle */}
+          <div className="flex items-center gap-2 whitespace-nowrap">
+            <label className="flex items-center gap-2 cursor-pointer flex-shrink-0">
+              <span className="text-sm font-medium text-black dark:text-white">
+              Data Stream Display
+              </span>
+              <div
+                onClick={() => {
+                  homeDispatch({
+                    field: 'showDataStreamDisplay',
+                    value: !showDataStreamDisplay,
+                  });
+                }}
+                className={`relative inline-flex h-5 w-10 items-center cursor-pointer rounded-full transition-colors duration-300 ease-in-out ${
+                  showDataStreamDisplay ? 'bg-black dark:bg-[#76b900]' : 'bg-gray-200'
+                }`}
+              >
+                <span
+                  className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform duration-300 ease-in-out ${
+                    showDataStreamDisplay ? 'translate-x-6' : 'translate-x-0'
                   }`}
                 />
               </div>

--- a/components/Chat/ChatHeader.tsx
+++ b/components/Chat/ChatHeader.tsx
@@ -207,6 +207,18 @@ export const ChatHeader = ({ webSocketModeRef = {} }) => {
             </label>
           </div>
 
+          {/* Database Updates Button */}
+          <div className="flex items-center">
+              <button
+                  onClick={() => window.open('/database-updates', '_blank')}
+                  className="flex items-center gap-2 px-3 py-1 text-sm text-black dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors"
+                  title="View Database Updates"
+              >
+                  <IconDatabase size={16} />
+                  <span className="hidden sm:inline">Data Updates</span>
+              </button>
+          </div>
+
           {/* Theme Toggle Button */}
           <div className="flex items-center dark:text-white text-black transition-colors duration-300">
             <button

--- a/components/Chat/ChatHeader.tsx
+++ b/components/Chat/ChatHeader.tsx
@@ -89,6 +89,10 @@ export const ChatHeader = ({ webSocketModeRef = {} }) => {
       <div
         className={`fixed right-0 top-0 h-12 flex items-center transition-all duration-300 ${
           isExpanded ? 'mr-2' : 'mr-2'
+        } ${
+          selectedConversation?.messages?.length === 0
+            ? 'bg-none'
+            : 'bg-[#76b900] dark:bg-black bo'
         }`}
       >
         <button

--- a/components/Chat/ChatHeader.tsx
+++ b/components/Chat/ChatHeader.tsx
@@ -8,12 +8,14 @@ import {
   IconUserFilled,
   IconChevronLeft,
   IconChevronRight,
+  IconDatabase,
 } from '@tabler/icons-react';
 import React, { useContext, useState, useRef, useEffect } from 'react';
 
 import { env } from 'next-runtime-env';
 
 import { getWorkflowName } from '@/utils/app/helper';
+import { useTheme } from '@/contexts/ThemeContext';
 
 import HomeContext from '@/pages/api/home/home.context';
 
@@ -34,12 +36,13 @@ export const ChatHeader = ({ webSocketModeRef = {} }) => {
       chatHistory,
       webSocketMode,
       webSocketConnected,
-      lightMode,
       selectedConversation,
       showDataStreamDisplay,
     },
     dispatch: homeDispatch,
   } = useContext(HomeContext);
+
+  const { lightMode, setLightMode } = useTheme();
 
   const handleLogin = () => {
     console.log('Login clicked');
@@ -205,10 +208,7 @@ export const ChatHeader = ({ webSocketModeRef = {} }) => {
             <button
               onClick={() => {
                 const newMode = lightMode === 'dark' ? 'light' : 'dark';
-                homeDispatch({
-                  field: 'lightMode',
-                  value: newMode,
-                });
+                setLightMode(newMode);
               }}
               className="rounded-full flex items-center justify-center bg-none dark:bg-gray-700 transition-colors duration-300 focus:outline-none"
             >

--- a/components/DataStreamDisplay/DataStreamDisplay.tsx
+++ b/components/DataStreamDisplay/DataStreamDisplay.tsx
@@ -7,7 +7,7 @@ interface DataStreamDisplayProps {
   onStreamChange: (stream: string) => void;
 }
 
-interface FinalizedTranscript {
+interface FinalizedDataEntry {
   text: string;
   stream_id: string;
   timestamp: number;
@@ -51,17 +51,17 @@ export const DataStreamDisplay: React.FC<DataStreamDisplayProps> = React.memo(({
         const response = await fetch(`/api/update-data-stream?type=finalized&stream=${selectedStream}`);
         if (response.ok) {
           const data = await response.json();
-          const transcripts: FinalizedTranscript[] = data.transcripts || [];
+          const entries: FinalizedDataEntry[] = data.entries || [];
 
-          if (transcripts.length > 0) {
-            // Find the most recent transcript for this stream
-            const sortedTranscripts = transcripts.sort((a, b) => {
+          if (entries.length > 0) {
+            // Find the most recent entry for this stream
+            const sortedEntries = entries.sort((a, b) => {
               const timestampA = parseTimestampAsUTC(a.timestamp);
               const timestampB = parseTimestampAsUTC(b.timestamp);
               return timestampB - timestampA; // Most recent first
             });
 
-            const latestTimestamp = parseTimestampAsUTC(sortedTranscripts[0].timestamp);
+            const latestTimestamp = parseTimestampAsUTC(sortedEntries[0].timestamp);
             setLastDbUpdate(latestTimestamp);
           } else {
             setLastDbUpdate(null);

--- a/components/DataStreamDisplay/DataStreamDisplay.tsx
+++ b/components/DataStreamDisplay/DataStreamDisplay.tsx
@@ -1,0 +1,166 @@
+
+import React, { useEffect, useRef, useState, useCallback } from 'react';
+
+interface DataStreamDisplayProps {
+  dataStreams: string[];
+  selectedStream: string;
+  onStreamChange: (stream: string) => void;
+}
+
+interface FinalizedTranscript {
+  text: string;
+  stream_id: string;
+  timestamp: number;
+  id: string;
+  uuid?: string;
+  pending?: boolean;
+}
+
+export const DataStreamDisplay: React.FC<DataStreamDisplayProps> = React.memo(({
+  dataStreams,
+  selectedStream,
+  onStreamChange
+}) => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [text, setText] = useState('');
+  const [lastDbUpdate, setLastDbUpdate] = useState<number | null>(null);
+
+  // Move polling logic into this component to isolate updates
+  useEffect(() => {
+    const interval = setInterval(async () => {
+      try {
+        // Get text for selected stream
+        const textRes = await fetch(`/api/update-data-stream?stream=${selectedStream}`);
+        if (textRes.ok) {
+          const textData = await textRes.json();
+          if (typeof textData.text === 'string') {
+            setText(textData.text);
+          }
+        }
+      } catch (err) {
+        // Optionally handle error
+      }
+    }, 100);
+    return () => clearInterval(interval);
+  }, [selectedStream]);
+
+  // Fetch last database update time for the selected stream
+  useEffect(() => {
+    const fetchLastDbUpdate = async () => {
+      try {
+        const response = await fetch(`/api/update-data-stream?type=finalized&stream=${selectedStream}`);
+        if (response.ok) {
+          const data = await response.json();
+          const transcripts: FinalizedTranscript[] = data.transcripts || [];
+
+          if (transcripts.length > 0) {
+            // Find the most recent transcript for this stream
+            const sortedTranscripts = transcripts.sort((a, b) => {
+              const timestampA = parseTimestampAsUTC(a.timestamp);
+              const timestampB = parseTimestampAsUTC(b.timestamp);
+              return timestampB - timestampA; // Most recent first
+            });
+
+            const latestTimestamp = parseTimestampAsUTC(sortedTranscripts[0].timestamp);
+            setLastDbUpdate(latestTimestamp);
+          } else {
+            setLastDbUpdate(null);
+          }
+        }
+      } catch (err) {
+        // Handle error silently
+        setLastDbUpdate(null);
+      }
+    };
+
+    if (selectedStream) {
+      fetchLastDbUpdate();
+      // Check for updates every 5 seconds
+      const interval = setInterval(fetchLastDbUpdate, 5000);
+      return () => clearInterval(interval);
+    }
+  }, [selectedStream]);
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [text]);
+
+  const formatStreamName = (streamId: string) => {
+    return streamId || 'Default Stream';
+  };
+
+  const parseTimestampAsUTC = (timestamp: string | number): number => {
+    if (typeof timestamp === 'number') return timestamp;
+    // Only add 'Z' if not already present
+    const utcString = timestamp.endsWith('Z') ? timestamp : timestamp + 'Z';
+    console.log(`[SERVER] Timestamp debug ${utcString}`);
+    return new Date(utcString).getTime();
+  };
+
+  const formatLastUpdateTime = (timestamp: number) => {
+    const now = Date.now();
+    const diff = now - timestamp;
+
+        // Less than 1 minute
+    if (diff < 60000) {
+      const seconds = Math.floor(diff / 1000);
+      return `${seconds}s ago`;
+    }
+
+    // Less than 1 hour
+    if (diff < 3600000) {
+      const minutes = Math.floor(diff / 60000);
+      return `${minutes}m ago`;
+    }
+
+    // Less than 1 day
+    if (diff < 86400000) {
+      const hours = Math.floor(diff / 3600000);
+      return `${hours}h ago`;
+    }
+
+    // More than 1 day - show date
+    return new Date(timestamp).toLocaleDateString();
+  };
+
+  return (
+    <div className="w-full sm:w-[95%] 2xl:w-[60%] mx-auto mt-1 mb-4">
+      <div className="flex justify-between items-center mb-2">
+        <div className="flex items-center gap-3">
+          <h2 className="text-left text-lg font-semibold text-black dark:text-white">
+            Live Data Streams
+          </h2>
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            {lastDbUpdate ? `Last DB update: ${formatLastUpdateTime(lastDbUpdate)}` : 'No database updates yet'}
+          </span>
+        </div>
+        {dataStreams.length > 1 && (
+          <div className="flex items-center gap-2">
+            <label className="text-sm text-black dark:text-white">Stream:</label>
+            <select
+              value={selectedStream}
+              onChange={(e) => onStreamChange(e.target.value)}
+              className="px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-black dark:text-white"
+            >
+              {dataStreams.map(stream => (
+                <option key={stream} value={stream}>
+                  {formatStreamName(stream)}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+      </div>
+      <div
+        ref={scrollRef}
+        className="bg-white dark:bg-gray-700 rounded-lg border border-gray-300 dark:border-gray-900 p-2 max-h-16 overflow-y-auto"
+      >
+        <p className="text-black dark:text-white whitespace-pre-wrap m-0">
+          {text || 'Waiting for data...'}
+        </p>
+      </div>
+    </div>
+  );
+});

--- a/components/Settings/SettingDialog.tsx
+++ b/components/Settings/SettingDialog.tsx
@@ -3,6 +3,7 @@ import toast from 'react-hot-toast';
 
 import { useTranslation } from 'next-i18next';
 
+import { useTheme } from '@/contexts/ThemeContext';
 import HomeContext from '@/pages/api/home/home.context';
 
 interface Props {
@@ -15,7 +16,6 @@ export const SettingDialog: FC<Props> = ({ open, onClose }) => {
   const modalRef = useRef<HTMLDivElement>(null);
   const {
     state: {
-      lightMode,
       chatCompletionURL,
       webSocketURL,
       webSocketSchema: schema,
@@ -27,7 +27,13 @@ export const SettingDialog: FC<Props> = ({ open, onClose }) => {
     dispatch: homeDispatch,
   } = useContext(HomeContext);
 
+  const { lightMode, setLightMode } = useTheme();
   const [theme, setTheme] = useState(lightMode);
+
+  // Sync local theme state with global lightMode
+  useEffect(() => {
+    setTheme(lightMode);
+  }, [lightMode]);
   const [chatCompletionEndPoint, setChatCompletionEndPoint] = useState(
     sessionStorage.getItem('chatCompletionURL') || chatCompletionURL,
   );
@@ -74,7 +80,7 @@ export const SettingDialog: FC<Props> = ({ open, onClose }) => {
       return;
     }
 
-    homeDispatch({ field: 'lightMode', value: theme });
+    setLightMode(theme);
     homeDispatch({ field: 'chatCompletionURL', value: chatCompletionEndPoint });
     homeDispatch({ field: 'webSocketURL', value: webSocketEndPoint });
     homeDispatch({ field: 'webSocketSchema', value: webSocketSchema });

--- a/contexts/ThemeContext.tsx
+++ b/contexts/ThemeContext.tsx
@@ -1,0 +1,61 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import { getSettings, saveSettings } from '@/utils/app/settings';
+
+interface ThemeContextType {
+  lightMode: 'light' | 'dark';
+  setLightMode: (mode: 'light' | 'dark') => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [lightMode, setLightModeState] = useState<'light' | 'dark'>('light');
+
+  // Wrapper function that saves settings when theme changes
+  const setLightMode = (mode: 'light' | 'dark') => {
+    setLightModeState(mode);
+    const currentSettings = getSettings();
+    saveSettings({ ...currentSettings, theme: mode });
+  };
+
+  useEffect(() => {
+    // Initialize theme from settings
+    const settings = getSettings();
+    if (settings.theme) {
+      setLightModeState(settings.theme);
+    }
+
+    // Listen for theme changes in localStorage/sessionStorage
+    const handleStorageChange = () => {
+      const settings = getSettings();
+      if (settings.theme) {
+        setLightModeState(settings.theme);
+      }
+    };
+
+    // Listen for storage events to sync theme across tabs
+    window.addEventListener('storage', handleStorageChange);
+
+    // Also check periodically for theme changes within the same tab
+    const interval = setInterval(handleStorageChange, 1000);
+
+    return () => {
+      window.removeEventListener('storage', handleStorageChange);
+      clearInterval(interval);
+    };
+  }, []);
+
+  return (
+    <ThemeContext.Provider value={{ lightMode, setLightMode }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,6 +5,8 @@ import { appWithTranslation } from 'next-i18next';
 import type { AppProps } from 'next/app';
 import { Inter } from 'next/font/google';
 
+import { ThemeProvider } from '@/contexts/ThemeContext';
+
 import '@/styles/globals.css';
 
 const inter = Inter({ subsets: ['latin'] });
@@ -23,7 +25,9 @@ function App({ Component, pageProps }: AppProps<{}>) {
         }}
       />
       <QueryClientProvider client={queryClient}>
-        <Component {...pageProps} />
+        <ThemeProvider>
+          <Component {...pageProps} />
+        </ThemeProvider>
       </QueryClientProvider>
     </div>
   );

--- a/pages/api/home/home.state.tsx
+++ b/pages/api/home/home.state.tsx
@@ -29,6 +29,8 @@ export interface HomeInitialState {
   intermediateStepOverride?: boolean;
   autoScroll?: boolean;
   additionalConfig: any;
+  dataStreams: string[];
+  showDataStreamDisplay: boolean;
 }
 
 export const initialState: HomeInitialState = {
@@ -73,4 +75,10 @@ export const initialState: HomeInitialState = {
   intermediateStepOverride: true,
   autoScroll: true,
   additionalConfig: {},
+  dataStreams: [],
+  showDataStreamDisplay:
+    env('NEXT_PUBLIC_SHOW_DATA_STREAM_DEFAULT_ON') === 'true' ||
+    process?.env?.NEXT_PUBLIC_SHOW_DATA_STREAM_DEFAULT_ON === 'true'
+      ? true
+      : false,
 };

--- a/pages/api/home/home.tsx
+++ b/pages/api/home/home.tsx
@@ -11,6 +11,7 @@ import { useCreateReducer } from '@/hooks/useCreateReducer';
 
 import { DataStreamDisplay } from '@/components/DataStreamDisplay/DataStreamDisplay';
 import { ChatHeader } from '@/components/Chat/ChatHeader';
+import { useTheme } from '@/contexts/ThemeContext';
 
 import {
   cleanConversationHistory,
@@ -52,9 +53,11 @@ const Home = (props: any) => {
   let workflow = APPLICATION_NAME;
 
   const {
-    state: { lightMode, folders, conversations, selectedConversation, dataStreams, showDataStreamDisplay },
+    state: { folders, conversations, selectedConversation, dataStreams, showDataStreamDisplay },
     dispatch,
   } = contextValue;
+
+  const { lightMode, setLightMode } = useTheme();
 
   const stopConversationRef = useRef<boolean>(false);
 
@@ -212,10 +215,7 @@ const Home = (props: any) => {
     workflow = getWorkflowName();
     const settings = getSettings();
     if (settings.theme) {
-      dispatch({
-        field: 'lightMode',
-        value: settings.theme,
-      });
+      setLightMode(settings.theme);
     }
 
     const showChatbar = sessionStorage.getItem('showChatbar');
@@ -269,7 +269,7 @@ const Home = (props: any) => {
       saveConversation(homepageConversation);
       saveConversations(updatedConversations);
     }
-  }, [dispatch, t]);
+  }, [dispatch, t, setLightMode]);
 
   // Poll /api/update-data-stream every 2 seconds to discover available streams
   useEffect(() => {

--- a/pages/api/update-data-stream.ts
+++ b/pages/api/update-data-stream.ts
@@ -1,0 +1,137 @@
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+// Module-level variable to store text for multiple streams
+interface TextData {
+  text: string;
+  stream_id: string;
+  timestamp: number;
+  finalized?: boolean;
+}
+
+interface FinalizedTranscript {
+  text: string;
+  stream_id: string;
+  timestamp: number;
+  id: string; // unique identifier for each finalized transcript
+  uuid?: string; // UUID from the backend for database tracking
+  pending?: boolean; // indicates if transcript is pending database processing
+}
+
+let streamTexts: { [streamId: string]: TextData } = {};
+let finalizedTranscripts: FinalizedTranscript[] = [];
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'POST') {
+    const { text, stream_id, timestamp, finalized, uuid } = req.body;
+    if (typeof text !== 'string') {
+      return res.status(400).json({ error: 'Text must be a string.' });
+    }
+    const streamId = stream_id || 'default';
+    const currentTimestamp = timestamp || Date.now();
+
+    if (finalized) {
+      // Store finalized transcript
+      const finalizedTranscript: FinalizedTranscript = {
+        text,
+        stream_id: streamId,
+        timestamp: currentTimestamp,
+        id: `${streamId}-${currentTimestamp}-${Math.random().toString(36).substr(2, 9)}`,
+        uuid: uuid, // Store the UUID from the backend
+        pending: true // Initially mark as pending database processing
+      };
+      finalizedTranscripts.push(finalizedTranscript);
+
+      // Sort by stream_id, then by timestamp
+      finalizedTranscripts.sort((a, b) => {
+        if (a.stream_id !== b.stream_id) {
+          return a.stream_id.localeCompare(b.stream_id);
+        }
+        return a.timestamp - b.timestamp;
+      });
+
+      // Clear the live text for this stream since it's now finalized
+      if (streamTexts[streamId]) {
+        streamTexts[streamId].text = '';
+      }
+    } else {
+      // Store live text
+      streamTexts[streamId] = {
+        text,
+        stream_id: streamId,
+        timestamp: currentTimestamp,
+        finalized: false
+      };
+    }
+
+    return res.status(200).json({ success: true });
+  }
+
+  if (req.method === 'GET') {
+    const { stream, type } = req.query;
+
+    if (type === 'finalized') {
+      // Get finalized transcripts
+      if (stream !== undefined) {
+        const streamId = stream as string;
+        const streamFinalizedTranscripts = finalizedTranscripts.filter(
+          transcript => transcript.stream_id === streamId
+        );
+        return res.status(200).json({
+          transcripts: streamFinalizedTranscripts,
+          stream_id: streamId
+        });
+      } else {
+        // Get all finalized transcripts
+        return res.status(200).json({
+          transcripts: finalizedTranscripts
+        });
+      }
+    }
+
+    if (stream !== undefined) {
+      // Get live text for specific stream
+      const streamId = stream as string;
+      const streamData = streamTexts[streamId];
+      return res.status(200).json({
+        text: streamData?.text || '',
+        stream_id: streamId
+      });
+    } else {
+      // Get all available streams with live text
+      const streams = Object.keys(streamTexts);
+      return res.status(200).json({
+        streams,
+        texts: streamTexts
+      });
+    }
+  }
+
+  // PATCH method for updating transcript processing status
+  if (req.method === 'PATCH') {
+    const { uuid, pending } = req.body;
+
+    if (!uuid) {
+      return res.status(400).json({ error: 'UUID is required.' });
+    }
+
+    // Find the transcript by UUID and update its pending status
+    const transcriptIndex = finalizedTranscripts.findIndex(
+      transcript => transcript.uuid === uuid
+    );
+
+    if (transcriptIndex === -1) {
+      return res.status(404).json({ error: 'Transcript not found.' });
+    }
+
+    finalizedTranscripts[transcriptIndex].pending = pending;
+
+    return res.status(200).json({
+      success: true,
+      transcript: finalizedTranscripts[transcriptIndex]
+    });
+  }
+
+  res.setHeader('Allow', ['GET', 'POST', 'PATCH']);
+  res.status(405).end(`Method ${req.method} Not Allowed`);
+}

--- a/pages/database-updates.tsx
+++ b/pages/database-updates.tsx
@@ -1,0 +1,341 @@
+
+import React, { useState, useEffect } from 'react';
+import { IconRefresh, IconFilter, IconHistory, IconSortAscending, IconSortDescending, IconClock, IconCheck } from '@tabler/icons-react';
+import { useTheme } from '@/contexts/ThemeContext';
+import Head from 'next/head';
+
+interface FinalizedDataEntry {
+  text: string;
+  stream_id: string;
+  timestamp: number;
+  id: string;
+  uuid?: string;
+  pending?: boolean;
+}
+
+const DataStreamHistory = () => {
+  const [entries, setEntries] = useState<FinalizedDataEntry[]>([]);
+  const [filteredEntries, setFilteredEntries] = useState<FinalizedDataEntry[]>([]);
+  const [selectedStream, setSelectedStream] = useState<string | null>(null);
+  const [availableStreams, setAvailableStreams] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [sortOrder, setSortOrder] = useState<'newest' | 'oldest'>(() => {
+    // Initialize from localStorage, fallback to 'newest'
+    if (typeof window !== 'undefined') {
+      return (localStorage.getItem('entry-sort-order') as 'newest' | 'oldest') || 'newest';
+    }
+    return 'newest';
+  });
+  const [pendingFilter, setPendingFilter] = useState<'all' | 'pending' | 'ingested'>(() => {
+    // Initialize from localStorage, fallback to 'all'
+    if (typeof window !== 'undefined') {
+      return (localStorage.getItem('entry-pending-filter') as 'all' | 'pending' | 'ingested') || 'all';
+    }
+    return 'all';
+  });
+
+  const { lightMode } = useTheme();
+  console.log('lightMode', lightMode);
+
+  // Save sort order to localStorage when it changes
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('entry-sort-order', sortOrder);
+    }
+  }, [sortOrder]);
+
+  // Save pending filter to localStorage when it changes
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('entry-pending-filter', pendingFilter);
+    }
+  }, [pendingFilter]);
+
+  // Fetch finalized entries
+  const fetchEntries = async () => {
+    try {
+      setLoading(true);
+      const response = await fetch('/api/update-data-stream?type=finalized');
+      if (!response.ok) {
+        throw new Error('Failed to fetch entries');
+      }
+      const data = await response.json();
+      setEntries(data.entries || []);
+
+      // Extract unique stream IDs
+      const streamIds = data.entries.map((t: FinalizedDataEntry) => t.stream_id);
+      const streams = Array.from(new Set<string>(streamIds)).sort((a: string, b: string) => a.localeCompare(b));
+      setAvailableStreams(streams);
+
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Filter and sort entries based on selected stream, pending status, and sort order
+  useEffect(() => {
+    let filtered = entries;
+
+    // Apply stream filter
+    if (selectedStream !== null) {
+      filtered = filtered.filter((t: FinalizedDataEntry) => t.stream_id === selectedStream);
+    }
+
+    // Apply pending status filter
+    if (pendingFilter !== 'all') {
+      filtered = filtered.filter((t: FinalizedDataEntry) => {
+        if (pendingFilter === 'pending') {
+          return t.pending === true;
+        } else if (pendingFilter === 'ingested') {
+          return t.pending === false;
+        }
+        return true;
+      });
+    }
+
+    // Apply sorting
+    filtered = [...filtered].sort((a, b) => {
+      // First sort by stream_id
+      if (a.stream_id !== b.stream_id) {
+        return a.stream_id.localeCompare(b.stream_id);
+      }
+      // Then sort by timestamp based on sort order
+      // Convert timestamps to numbers to ensure proper comparison
+      const timestampA = typeof a.timestamp === 'string' ? new Date(a.timestamp).getTime() : a.timestamp;
+      const timestampB = typeof b.timestamp === 'string' ? new Date(b.timestamp).getTime() : b.timestamp;
+
+      if (sortOrder === 'newest') {
+        return timestampB - timestampA; // Newest first
+      } else {
+        return timestampA - timestampB; // Oldest first
+      }
+    });
+
+    setFilteredEntries(filtered);
+  }, [entries, selectedStream, pendingFilter, sortOrder]);
+
+  // Initial load and periodic refresh
+  useEffect(() => {
+    fetchEntries();
+    const interval = setInterval(fetchEntries, 5000); // Refresh every 5 seconds
+    return () => clearInterval(interval);
+  }, []);
+
+  const formatTimestamp = (timestamp: number) => {
+    return new Date(timestamp).toLocaleString();
+  };
+
+  const formatStreamName = (streamId: string) => {
+    return streamId || 'Default Stream';
+  };
+
+  const getStreamColor = (streamId: string) => {
+    // Generate a consistent color based on stream ID hash
+    let hash = 0;
+    for (let i = 0; i < streamId.length; i++) {
+      const char = streamId.charCodeAt(i);
+      hash = ((hash << 5) - hash) + char;
+      hash = hash & hash; // Convert to 32-bit integer
+    }
+
+    const colors = [
+      'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+      'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+      'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+      'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+      'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200',
+      'bg-pink-100 text-pink-800 dark:bg-pink-900 dark:text-pink-200',
+      'bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200',
+      'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200',
+    ];
+    return colors[Math.abs(hash) % colors.length];
+  };
+
+  return (
+    <>
+      <Head>
+        <title>Database Updates</title>
+        <meta name="description" content="View and manage database entry updates" />
+        <link rel="icon" href="/nvidia.jpg" />
+      </Head>
+
+      <div className={`min-h-screen ${lightMode === 'dark' ? 'dark' : ''}`}>
+        <div className="bg-white dark:bg-gray-900 min-h-screen">
+          {/* Header */}
+          <div className="bg-[#76b900] dark:bg-gray-800 shadow-sm">
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+              <div className="flex items-center justify-between h-16">
+                <div className="flex items-center space-x-3">
+                  <IconHistory className="w-8 h-8 text-white" />
+                  <h1 className="text-xl font-semibold text-white">
+                    Database History
+                  </h1>
+                </div>
+                <div className="flex items-center space-x-3">
+                  <button
+                    onClick={() => setSortOrder(sortOrder === 'newest' ? 'oldest' : 'newest')}
+                    className="flex items-center space-x-2 px-4 py-2 bg-white bg-opacity-20 hover:bg-opacity-30 rounded-md text-white transition-colors"
+                    title={`Sort by ${sortOrder === 'newest' ? 'oldest first' : 'newest first'}`}
+                  >
+                    {sortOrder === 'newest' ? (
+                      <IconSortDescending className="w-4 h-4" />
+                    ) : (
+                      <IconSortAscending className="w-4 h-4" />
+                    )}
+                    <span className="hidden sm:inline">
+                      {sortOrder === 'newest' ? 'Newest' : 'Oldest'}
+                    </span>
+                  </button>
+                  <button
+                    onClick={fetchEntries}
+                    disabled={loading}
+                    className="flex items-center space-x-2 px-4 py-2 bg-white bg-opacity-20 hover:bg-opacity-30 rounded-md text-white transition-colors disabled:opacity-50"
+                  >
+                    <IconRefresh className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
+                    <span>Refresh</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Content */}
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+            {/* Filters */}
+            <div className="mb-6">
+              <div className="flex items-center space-x-4 flex-wrap gap-y-2">
+                <IconFilter className="w-5 h-5 text-gray-500 dark:text-gray-400" />
+
+                {/* Stream Filter */}
+                <select
+                  value={selectedStream ?? ''}
+                  onChange={(e) => setSelectedStream(e.target.value ? e.target.value : null)}
+                  className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-[#76b900] focus:border-transparent"
+                >
+                  <option value="">All Streams</option>
+                  {availableStreams.map((streamId: string) => (
+                    <option key={streamId} value={streamId}>
+                      {formatStreamName(streamId)}
+                    </option>
+                  ))}
+                </select>
+
+                {/* Pending Status Filter */}
+                <select
+                  value={pendingFilter}
+                  onChange={(e) => setPendingFilter(e.target.value as 'all' | 'pending' | 'ingested')}
+                  className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-[#76b900] focus:border-transparent"
+                >
+                  <option value="all">Any Status</option>
+                  <option value="pending">Pending</option>
+                  <option value="ingested">Ingested</option>
+                </select>
+
+                <span className="text-sm text-gray-500 dark:text-gray-400">
+                  {filteredEntries.length} {filteredEntries.length !== 1 ? 'entries' : 'entry'}
+                </span>
+              </div>
+            </div>
+
+            {/* Error State */}
+            {error && (
+              <div className="mb-6 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md">
+                <p className="text-red-800 dark:text-red-200">Error: {error}</p>
+              </div>
+            )}
+
+            {/* Loading State */}
+            {loading && entries.length === 0 && (
+              <div className="flex justify-center items-center py-12">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[#76b900]"></div>
+              </div>
+            )}
+
+            {/* Empty State */}
+            {!loading && filteredEntries.length === 0 && !error && (
+              <div className="text-center py-12">
+                <IconHistory className="mx-auto h-12 w-12 text-gray-400 dark:text-gray-500" />
+                <h3 className="mt-2 text-sm font-medium text-gray-900 dark:text-gray-100">
+                  No entries found
+                </h3>
+                <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                  {selectedStream !== null
+                    ? `No finalized entries for ${formatStreamName(selectedStream)}`
+                    : 'No finalized entries available'
+                  }
+                </p>
+              </div>
+            )}
+
+            {/* Entries List */}
+            {filteredEntries.length > 0 && (
+              <div className="space-y-4">
+                {filteredEntries.map((entry: FinalizedDataEntry) => (
+                  <div
+                    key={entry.id}
+                    className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 shadow-sm hover:shadow-md transition-shadow"
+                  >
+                    <div className="flex items-start justify-between mb-3">
+                      <div className="flex items-center space-x-3">
+                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getStreamColor(entry.stream_id)}`}>
+                          {formatStreamName(entry.stream_id)}
+                        </span>
+                        {/* Processing Status Indicator */}
+                        {entry.pending !== undefined && (
+                          <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                            entry.pending
+                              ? 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200'
+                              : 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
+                          }`}>
+                            {entry.pending ? (
+                              <>
+                                <IconClock className="w-3 h-3 mr-1" />
+                                Database Pending
+                              </>
+                            ) : (
+                              <>
+                                <IconCheck className="w-3 h-3 mr-1" />
+                                Database Ingested
+                              </>
+                            )}
+                          </span>
+                        )}
+                        <span className="text-sm text-gray-500 dark:text-gray-400">
+                          {formatTimestamp(entry.timestamp)}
+                        </span>
+                        {/* UUID Display (for debugging/admin purposes) */}
+                        {entry.uuid && (
+                          <span className="text-xs text-gray-400 dark:text-gray-500 font-mono">
+                            ID: {entry.uuid.substring(0, 8)}...
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    <div className="prose prose-sm max-w-none dark:prose-invert">
+                      <p className="text-gray-900 dark:text-gray-100 leading-relaxed whitespace-pre-wrap">
+                        {entry.text}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default DataStreamHistory;
+
+// Disable server-side rendering for this page since it needs client-side context
+export const getServerSideProps = async () => {
+  return {
+    props: {}
+  };
+};

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -14,6 +14,7 @@ export type Role = 'assistant' | 'user' | 'agent' | 'system';
 export interface ChatBody {
   chatCompletionURL?: string;
   messages?: Message[];
+  conversationId?: string;
   additionalProps?: any;
 }
 

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -24,6 +24,7 @@ export interface Conversation {
   messages: Message[];
   folderId: string | null;
   isHomepageConversation?: boolean; // Flag to track homepage conversations before first message
+  selectedStream?: string;
 }
 
 // WebSocket Message Types

--- a/utils/app/settings.ts
+++ b/utils/app/settings.ts
@@ -6,7 +6,7 @@ export const getSettings = (): Settings => {
   let settings: Settings = {
     theme: 'light',
   };
-  const settingsJson = sessionStorage.getItem(STORAGE_KEY);
+  const settingsJson = localStorage.getItem(STORAGE_KEY);
   if (settingsJson) {
     try {
       let savedSettings = JSON.parse(settingsJson) as Settings;
@@ -19,5 +19,5 @@ export const getSettings = (): Settings => {
 };
 
 export const saveSettings = (settings: Settings) => {
-  sessionStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
 };


### PR DESCRIPTION
## Description
Incorporates the changes required to run the [Streaming Data to RAG Developer Example](https://build.nvidia.com/nvidia/streaming-data-to-rag). All changes are optional, and the default behavior of the UI should not be affected.

Added documentation for using the new APIs in `DATA_STREAMING.md`.

### Changes
#### 1. Add an endpoint (`/chat/ca-rag`) for handling Q&A with [Context-Aware RAG backend](https://github.com/NVIDIA/context-aware-rag)

#### 2. Add API for displaying live data streams, along with visualization bar at top (default: OFF)
<img width="1538" height="256" alt="new-settings-bar" src="https://github.com/user-attachments/assets/cdccdb85-6208-40ed-b015-ee08ea4a42b4" />
<img width="1540" height="270" alt="live-data-stream-example" src="https://github.com/user-attachments/assets/f0cd3835-9f39-4bcd-bfbb-acc5cba69237" />

#### 3. Add page for displaying database entries and their status
<img width="1532" height="777" alt="database-history-example" src="https://github.com/user-attachments/assets/0d4d7f93-ebfb-463d-8017-a855097c47ce" />

#### 4. Enable light/dark theme across all pages
<img width="1847" height="910" alt="dark-mode" src="https://github.com/user-attachments/assets/9a30b71e-18cc-4cd4-a895-43639c1033a8" />

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit-UI/blob/main/CODE-OF-CONDUCT.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
