### PR TITLE
Fix inline code display for text wrapped in single backticks

### DIFF
--- a/components/Markdown/CustomComponents.tsx
+++ b/components/Markdown/CustomComponents.tsx
@@ -32,6 +32,19 @@ export const getReactMarkDownCustomComponents = (
           //   children[0] = children.length > 0 ? (children[0] as string)?.replace("`▍`", "▍") : '';
           // }
 
+          // Handle inline code (single backticks)
+          if (inline) {
+            return (
+              <code
+                className="bg-gray-200 dark:bg-gray-800 text-[#76b900] px-1 py-0.5 rounded before:content-none after:content-none"
+                {...props}
+              >
+                {children}
+              </code>
+            );
+          }
+
+          // Handle code blocks (triple backticks)
           const match = /language-(\w+)/.exec(className || '');
 
           return (


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->

Previously, text wrapped in single backticks were being displayed as a code block. For example, given this content:
```
This is wrapped in `single backticks` and should appear inline. 
The following is wrapped in triple backticks with line breaks:  \n```typescript\nhello world\n```\n 
The above should appear as a code block.
```
The output would be rendered as below:
<img width="915" height="297" alt="image" src="https://github.com/user-attachments/assets/28610335-a9e5-4a51-bb89-6a4ce82279e8" />

WIth this PR, the inline code should be rendered inline as below – note this will not impact display of triple-backtick code blocks:
<img width="901" height="241" alt="image" src="https://github.com/user-attachments/assets/04db8b4f-ef47-4821-9243-ef2006db298e" />
Dark Mode:
<img width="896" height="233" alt="image" src="https://github.com/user-attachments/assets/4526e6a1-0e3e-4a3a-abe6-d1e4be53c76f" />



## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit-UI/blob/main/CODE-OF-CONDUCT.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline code in Markdown now renders as inline snippets with consistent styling and behavior.
  * Code blocks continue to use the established block presentation.

* **Bug Fixes**
  * Prevents inline code from being treated as code blocks, improving readability within paragraphs and lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->