### PR TITLE
Improve chart readability with angled labels and support additional customization options

### DIFF
--- a/components/Markdown/Chart.tsx
+++ b/components/Markdown/Chart.tsx
@@ -59,6 +59,7 @@ const Chart = (props: any) => {
     ChartType = '',
     ChartHeight = 300,
     Data = [],
+    LegendProps = {},
     XAxisKey = '',
     YAxisKey = '',
     ValueKey = '',
@@ -134,7 +135,7 @@ const Chart = (props: any) => {
               <XAxis {...defaultXAxisProps} />
               <YAxis />
               <Tooltip />
-              <Legend />
+              <Legend {...LegendProps} />
               <Bar dataKey={YAxisKey} name={SeriesLabel} fill={colors.fill} />
             </BarChart>
           </ResponsiveContainer>
@@ -148,7 +149,7 @@ const Chart = (props: any) => {
               <XAxis {...defaultXAxisProps} />
               <YAxis />
               <Tooltip />
-              <Legend />
+              <Legend {...LegendProps} />
               <Line type="monotone" dataKey={YAxisKey} name={SeriesLabel} stroke={colors.fill}  />
             </LineChart>
           </ResponsiveContainer>
@@ -159,7 +160,7 @@ const Chart = (props: any) => {
           <ResponsiveContainer {...defaultContainerProps}>
             <PieChart id={`chart-PieChart-${Label}`}>
               <Tooltip />
-              <Legend />
+              <Legend {...LegendProps} />
               <Pie
                 data={Data}
                 dataKey={ValueKey}
@@ -183,7 +184,7 @@ const Chart = (props: any) => {
               <XAxis {...defaultXAxisProps} />
               <YAxis />
               <Tooltip />
-              <Legend />
+              <Legend {...LegendProps} />
               <Area
                 type="monotone"
                 dataKey={YAxisKey}
@@ -209,7 +210,7 @@ const Chart = (props: any) => {
                 fill={colors.fill}
                 fillOpacity={0.6}
               />
-              <Legend />
+              <Legend {...LegendProps} />
             </RadarChart>
           </ResponsiveContainer>
         );
@@ -222,7 +223,7 @@ const Chart = (props: any) => {
               <XAxis type="number" {...defaultXAxisProps} />
               <YAxis type="number" dataKey={YAxisKey} name={YAxisKey} />
               <Tooltip cursor={{ strokeDasharray: '3 3' }} />
-              <Legend />
+              <Legend {...LegendProps} />
               <Scatter data={Data} name={SeriesLabel} fill={colors.fill} />
             </ScatterChart>
           </ResponsiveContainer>
@@ -236,7 +237,7 @@ const Chart = (props: any) => {
               <XAxis {...defaultXAxisProps} />
               <YAxis />
               <Tooltip />
-              <Legend />
+              <Legend {...LegendProps} />
               <Bar dataKey={BarKey} name={SeriesLabelMap.bar} fill={colors.fill} />
               <Line dataKey={LineKey} name={SeriesLabelMap.line} stroke={colors.stroke} type="monotone" />
             </ComposedChart>


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
This PR introduces several enhancements to the `Chart` component, providing clearer visualizations and improving developer experience with additional customization options.

- Added customizable `ChartHeight` prop (defaults to 300 as before; used in Pie and Radar Chart examples below)
- Added customizable series label with `SeriesLabel` prop and `SeriesLabelMap` prop (applicable to `ComposedChart`). This allows for setting human readable axis label instead of using the raw data keys
- Added `LegendProps` to allow for legend customizations for layout, positioning, etc.
- Displaying x-axis labels at an angle and truncating long labels with ellipsis. This fixes the issue where some labels are not displayed due to lack of space, for example:  <img width="1290" height="338" alt="image" src="https://github.com/user-attachments/assets/5503147a-3e32-489c-9074-0cf903b0de88" />

## Example Chart Outputs
The screenshots below show the improved chart outputs:

<img width="1049" height="1316" alt="image" src="https://github.com/user-attachments/assets/5ad4fb24-17a3-4197-bb17-4b7f6a32a9d7" /><img width="978" height="1329" alt="image" src="https://github.com/user-attachments/assets/6bf2482c-a433-4e69-b7a3-970fdbf8330a" />



## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit-UI/blob/main/CODE-OF-CONDUCT.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
