### PR TITLE
Prevent stale ref data from overwriting conversation updates

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -277,11 +277,6 @@ export const Chat = () => {
     selectedConversationRef.current = selectedConversation;
   }, [selectedConversation]);
 
-  // Keep conversations ref up to date to avoid stale closure
-  useEffect(() => {
-    conversationsRef.current = conversations;
-  }, [conversations]);
-
   // Reset WebSocket state when conversation changes to prevent stale message display
   useEffect(() => {
     if (selectedConversation?.id) {
@@ -804,6 +799,11 @@ export const Chat = () => {
               }
               return conversation;
             });
+          
+          // Update ref immediately to prevent stale reads
+          conversationsRef.current = updatedConversations;
+          selectedConversationRef.current = updatedConversation;
+          
           // Removed fallback block that was wiping conversations
           homeDispatch({
             field: 'conversations',


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Use existing write-through pattern and remove conflicting useEffect sync to ensure conversation refs are updated before state changes and preventing race condition during re-renders. Previously, useEffect could fire with stale state during re-renders, causing refs to lose response content for the last assistant message.

Closes #75 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit-UI/blob/main/CODE-OF-CONDUCT.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
