### PR TITLE
Fix inline code detection for react-markdown v10

### DIFF
--- a/components/Markdown/CustomComponents.tsx
+++ b/components/Markdown/CustomComponents.tsx
@@ -17,7 +17,6 @@ export const getReactMarkDownCustomComponents = (
       code: memo(
         ({
           node,
-          inline,
           className,
           children,
           ...props
@@ -25,8 +24,14 @@ export const getReactMarkDownCustomComponents = (
           children: React.ReactNode;
           [key: string]: any;
         }) => {
-          // Handle inline code (single backticks)
-          if (inline) {
+          // Check for language class - only code blocks (triple backticks) have language-xxx
+          // In react-markdown v10+, the `inline` prop was removed, so we detect inline code
+          // by checking for absence of a language class
+          const match = /language-(\w+)/.exec(className || '');
+          const isInline = !match;
+
+          // Handle inline code (single backticks) - no language class
+          if (isInline) {
             return (
               <code
                 className="bg-gray-200 dark:bg-gray-800 text-[#76b900] px-1 py-0.5 rounded before:content-none after:content-none"
@@ -37,13 +42,11 @@ export const getReactMarkDownCustomComponents = (
             );
           }
 
-          // Handle code blocks (triple backticks)
-          const match = /language-(\w+)/.exec(className || '');
-
+          // Handle code blocks (triple backticks) - has language class
           return (
             <CodeBlock
               key={Math.random()}
-              language={(match && match.length > 1 && match[1]) || ''}
+              language={match[1] || ''}
               value={String(children).replace(/\n$/, '')}
               {...props}
             />


### PR DESCRIPTION
## Description

PR #49 fixed inline code rendering by checking `if (inline)`. However, commit c86bc43 upgraded `react-markdown` from v8.0.5 to v10.1.0, which removed the `inline` prop (deprecated in v9).

This caused a regression where inline code (single backticks) renders as block-level code blocks instead of inline snippets.

### Root Cause

| Version | `inline` prop | Behavior |
|---------|---------------|----------|
| v8.0.5 | ✅ Passed | `if (inline)` works correctly |
| v10.1.0 | ❌ Removed | `inline` is always `undefined`, check always fails |

### Solution

Detect inline vs block code by checking for the `language-xxx` CSS class, which react-markdown only adds to code blocks with a specified language:

| Markdown | `className` | Detection |
|----------|-------------|-----------|
| `` `code` `` (inline) | `undefined` | No language class → **inline** |
| ` ... ``` ` (block) | `"language-js"` | Has language class → **block** |

**Before:**

    if (inline) {  // Always false in v10 - inline is undefined
<img width="798" height="451" alt="image" src="https://github.com/user-attachments/assets/5b39a554-ad8e-476b-b419-384037580d8f" />


**After:**

    const match = /language-(\w+)/.exec(className || '');
    const isInline = !match;  // No language class = inline code
<img width="805" height="373" alt="image" src="https://github.com/user-attachments/assets/532a21e3-f77a-42da-b148-b15a75e18e7a" />


## By Submitting this PR I confirm:

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit-UI/blob/main/CODE-OF-CONDUCT.md).
- [x] We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- [x] When the PR is ready for review, new or existing tests cover these changes.
- [x] When the PR is ready for review, the documentation is up to date with these changes.