### PR TITLE
fix(Chat): Enable vertical scrolling for message container

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -1422,7 +1422,7 @@ export const Chat = () => {
     <div className="relative flex-1 overflow-hidden bg-white dark:bg-[#343541] transition-all duration-300 ease-in-out">
       <>
         <div
-          className="max-h-full overflow-x-hidden"
+          className="max-h-full overflow-x-hidden overflow-y-auto"
           ref={chatContainerRef}
           onScroll={handleScroll}
         >


### PR DESCRIPTION
 ## Summary
  - Fixed inability to scroll through chat messages when conversation exceeds viewport height
  - Added `overflow-y-auto` to the chat message container

  ## Problem
  The chat container at `components/Chat/Chat.tsx` was configured with `overflow-x-hidden`
  but lacked vertical overflow handling. Combined with the parent's `overflow-hidden`,
  this prevented users from scrolling to view messages beyond the initial viewport.

  ## Solution
  Added `overflow-y-auto` class to enable vertical scrolling while preserving the
  existing horizontal overflow behavior.

  ## Testing
  - [x] Verified scrolling works with multiple messages
  - [x] Confirmed auto-scroll during streaming still functions
  - [x] Tested scroll-to-bottom button behavior