### PR TITLE
Display numerical markers for ordered lists

### DIFF
--- a/components/Markdown/CustomComponents.tsx
+++ b/components/Markdown/CustomComponents.tsx
@@ -117,9 +117,29 @@ export const getReactMarkDownCustomComponents = (
           isEqual(prevProps.children, nextProps.children),
       ),
 
+      ol: memo(
+        ({ children, ...props }) => (
+          <ol className="list-decimal" {...props}>
+            {children}
+          </ol>
+        ),
+        (prevProps, nextProps) =>
+          isEqual(prevProps.children, nextProps.children),
+      ),
+
+      ul: memo(
+        ({ children, ...props }) => (
+          <ul className="list-disc" {...props}>
+            {children}
+          </ul>
+        ),
+        (prevProps, nextProps) =>
+          isEqual(prevProps.children, nextProps.children),
+      ),
+
       li: memo(
         ({ children, ...props }) => (
-          <li className="leading-[1.35rem] mb-1 list-disc" {...props}>
+          <li className="leading-[1.35rem]" {...props}>
             {children}
           </li>
         ),


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->

This PR adds separate markdown rendering handlers for ol and ul tags 

<img width="306" height="518" alt="image" src="https://github.com/user-attachments/assets/70c9e2eb-0051-487c-b9eb-a375c072528b" />

Closes #91 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit-UI/blob/main/CODE-OF-CONDUCT.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
