### PR TITLE
Add configurable WebSocket connection parameters

### DIFF
--- a/__tests__/utils/app/settingsValidation.test.ts
+++ b/__tests__/utils/app/settingsValidation.test.ts
@@ -1,0 +1,137 @@
+import {
+  validateOptionalGenerationJson,
+  validateWebSocketCustomParams,
+} from '@/utils/app/settingsValidation';
+
+describe('validateOptionalGenerationJson', () => {
+  it('accepts empty or whitespace', () => {
+    expect(validateOptionalGenerationJson('').isValid).toBe(true);
+    expect(validateOptionalGenerationJson('   ').isValid).toBe(true);
+  });
+
+  it('rejects non-object JSON', () => {
+    expect(validateOptionalGenerationJson('[]').isValid).toBe(false);
+    expect(validateOptionalGenerationJson('null').isValid).toBe(false);
+  });
+
+  it('rejects reserved field "messages" and reports only that key', () => {
+    const r = validateOptionalGenerationJson('{"messages": []}');
+    expect(r.isValid).toBe(false);
+    expect(r.error).toContain('messages');
+    expect(r.error).not.toContain('stream');
+  });
+
+  it('rejects reserved field "stream" and reports only that key', () => {
+    const r = validateOptionalGenerationJson('{"stream": true}');
+    expect(r.isValid).toBe(false);
+    expect(r.error).toContain('stream');
+    expect(r.error).not.toContain('messages');
+  });
+
+  it('rejects both reserved fields and reports both in error', () => {
+    const r = validateOptionalGenerationJson('{"messages": [], "stream": true}');
+    expect(r.isValid).toBe(false);
+    expect(r.error).toContain('messages');
+    expect(r.error).toContain('stream');
+  });
+
+  it('accepts valid custom params', () => {
+    expect(validateOptionalGenerationJson('{"temperature": 0.7}').isValid).toBe(true);
+    expect(validateOptionalGenerationJson('{"max_tokens": 100}').isValid).toBe(true);
+  });
+});
+
+describe('validateWebSocketCustomParams', () => {
+  it('accepts empty or whitespace', () => {
+    expect(validateWebSocketCustomParams('').isValid).toBe(true);
+    expect(validateWebSocketCustomParams('   ').isValid).toBe(true);
+  });
+
+  it('rejects invalid JSON or non-object', () => {
+    expect(validateWebSocketCustomParams('not json').isValid).toBe(false);
+    expect(validateWebSocketCustomParams('[]').isValid).toBe(false);
+  });
+
+  it('rejects top-level keys other than query, headers, payload', () => {
+    const r = validateWebSocketCustomParams('{"body": {}}');
+    expect(r.isValid).toBe(false);
+    expect(r.error).toContain('query, headers, payload');
+  });
+
+  describe('query reserved keys', () => {
+    it('rejects only "session" and error mentions only session', () => {
+      const r = validateWebSocketCustomParams(
+        '{"query": {"tenant_id": "acme", "session": "should-fail"}}',
+      );
+      expect(r.isValid).toBe(false);
+      expect(r.error).toContain('query: reserved keys (session) cannot be used');
+      expect(r.error).not.toContain('conversation_id');
+    });
+
+    it('rejects only "conversation_id" and error mentions only conversation_id', () => {
+      const r = validateWebSocketCustomParams(
+        '{"query": {"conversation_id": "abc"}}',
+      );
+      expect(r.isValid).toBe(false);
+      expect(r.error).toContain('query: reserved keys (conversation_id) cannot be used');
+      expect(r.error).not.toContain('session');
+    });
+
+    it('rejects both and error mentions both keys', () => {
+      const r = validateWebSocketCustomParams(
+        '{"query": {"session": "x", "conversation_id": "y"}}',
+      );
+      expect(r.isValid).toBe(false);
+      expect(r.error).toContain('session');
+      expect(r.error).toContain('conversation_id');
+    });
+
+    it('accepts query without reserved keys', () => {
+      expect(
+        validateWebSocketCustomParams('{"query": {"tenant_id": "acme"}}').isValid,
+      ).toBe(true);
+    });
+  });
+
+  describe('payload reserved keys', () => {
+    it('rejects only "type" and error mentions only type', () => {
+      const r = validateWebSocketCustomParams(
+        '{"payload": {"tenant_id": "acme", "type": "user"}}',
+      );
+      expect(r.isValid).toBe(false);
+      expect(r.error).toContain('payload: reserved keys (type) cannot be used');
+      expect(r.error).not.toContain('content');
+    });
+
+    it('rejects only "content" and error mentions only content', () => {
+      const r = validateWebSocketCustomParams(
+        '{"payload": {"content": "hello"}}',
+      );
+      expect(r.isValid).toBe(false);
+      expect(r.error).toContain('payload: reserved keys (content) cannot be used');
+    });
+
+    it('rejects multiple reserved keys and error mentions only those used', () => {
+      const r = validateWebSocketCustomParams(
+        '{"payload": {"type": "user", "content": "hi", "id": "1"}}',
+      );
+      expect(r.isValid).toBe(false);
+      expect(r.error).toContain('type');
+      expect(r.error).toContain('content');
+      expect(r.error).toContain('id');
+    });
+
+    it('accepts payload without reserved keys', () => {
+      expect(
+        validateWebSocketCustomParams('{"payload": {"tenant_id": "acme"}}').isValid,
+      ).toBe(true);
+    });
+  });
+
+  it('accepts valid full object', () => {
+    const r = validateWebSocketCustomParams(
+      '{"query": {"tenant_id": "a"}, "headers": {"X-Tenant": "a"}, "payload": {"tenant_id": "a"}}',
+    );
+    expect(r.isValid).toBe(true);
+  });
+});

--- a/utils/app/settingsValidation.ts
+++ b/utils/app/settingsValidation.ts
@@ -1,0 +1,120 @@
+export const CHAT_OPTIONAL_GENERATION_RESERVED_FIELDS = [
+  'messages',
+  'stream',
+] as const;
+
+export const WEBSOCKET_CUSTOM_PARAMS_TOP_KEYS = [
+  'query',
+  'headers',
+  'payload',
+] as const;
+
+export const WEBSOCKET_QUERY_RESERVED_KEYS = [
+  'session',
+  'conversation_id',
+] as const;
+
+export const WEBSOCKET_PAYLOAD_RESERVED_KEYS = [
+  'type',
+  'id',
+  'conversation_id',
+  'content',
+  'schema_type',
+  'thread_id',
+  'parent_id',
+  'timestamp',
+] as const;
+
+export function validateOptionalGenerationJson(
+  jsonString: string,
+): { isValid: boolean; error: string } {
+  if (!jsonString.trim()) {
+    return { isValid: true, error: '' };
+  }
+
+  try {
+    const parsed = JSON.parse(jsonString);
+
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return { isValid: false, error: 'JSON must be a valid object (not array or null)' };
+    }
+
+    const optionalReserved = new Set<string>(CHAT_OPTIONAL_GENERATION_RESERVED_FIELDS);
+    const conflictingFields = Object.keys(parsed).filter((key) =>
+      optionalReserved.has(key),
+    );
+
+    if (conflictingFields.length > 0) {
+      return {
+        isValid: false,
+        error: `Cannot override reserved fields: ${conflictingFields.join(', ')}`,
+      };
+    }
+
+    return { isValid: true, error: '' };
+  } catch {
+    return { isValid: false, error: 'Invalid JSON format' };
+  }
+}
+
+export function validateWebSocketCustomParams(
+  jsonString: string,
+): { isValid: boolean; error: string } {
+  if (!jsonString.trim()) return { isValid: true, error: '' };
+  try {
+    const parsed = JSON.parse(jsonString);
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return { isValid: false, error: 'Must be a JSON object' };
+    }
+    const allowedTopKeys = new Set<string>(WEBSOCKET_CUSTOM_PARAMS_TOP_KEYS);
+    const extraKeys = Object.keys(parsed).filter((k) => !allowedTopKeys.has(k));
+    if (extraKeys.length > 0) {
+      return {
+        isValid: false,
+        error: `Top-level keys must be one of: query, headers, payload. Found: ${extraKeys.join(', ')}`,
+      };
+    }
+    if (parsed.query != null) {
+      if (typeof parsed.query !== 'object' || Array.isArray(parsed.query)) {
+        return { isValid: false, error: 'query must be an object' };
+      }
+      const queryReserved = new Set<string>(WEBSOCKET_QUERY_RESERVED_KEYS);
+      const used = Object.keys(parsed.query).filter((k) => queryReserved.has(k));
+      if (used.length > 0) {
+        return {
+          isValid: false,
+          error: `query: reserved keys (${used.join(', ')}) cannot be used.`,
+        };
+      }
+    }
+    if (parsed.headers != null) {
+      if (typeof parsed.headers !== 'object' || Array.isArray(parsed.headers)) {
+        return { isValid: false, error: 'headers must be an object' };
+      }
+      const nonString = Object.entries(parsed.headers).find(
+        ([, v]) => typeof v !== 'string' && typeof v !== 'number',
+      );
+      if (nonString) {
+        return { isValid: false, error: 'headers values must be strings or numbers.' };
+      }
+    }
+    if (parsed.payload != null) {
+      if (typeof parsed.payload !== 'object' || Array.isArray(parsed.payload)) {
+        return { isValid: false, error: 'payload must be an object' };
+      }
+      const payloadReserved = new Set<string>(WEBSOCKET_PAYLOAD_RESERVED_KEYS);
+      const payloadUsed = Object.keys(parsed.payload).filter((k) =>
+        payloadReserved.has(k),
+      );
+      if (payloadUsed.length > 0) {
+        return {
+          isValid: false,
+          error: `payload: reserved keys (${payloadUsed.join(', ')}) cannot be used.`,
+        };
+      }
+    }
+    return { isValid: true, error: '' };
+  } catch {
+    return { isValid: false, error: 'Invalid JSON' };
+  }
+}


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close -->

Improves support for WebSocket connection parameters in Settings:

- **Connection Parameters (née Custom WebSocket Parameters):** Renamed section and collapsible UI. Single JSON field with optional top-level keys: `query` (URL params), `headers` (handshake), `payload` (merged into each message). Reserved keys for query and payload are validated and cannot be overridden.
- **Validation:** Connection params validated on input; errors list only the reserved keys that were used. Reserved keys live in `utils/app/settingsValidation.ts` (`CHAT_OPTIONAL_GENERATION_RESERVED_FIELDS`, `WEBSOCKET_QUERY_RESERVED_KEYS`, `WEBSOCKET_PAYLOAD_RESERVED_KEYS`).
- **Payload key:** Custom message payload is under the `payload` key (replacing `body`) in the Connection Parameters JSON.
- **UX:** Formatted multi-line placeholders and clearer helper text for Optional generation parameters and Connection Parameters; both sections are collapsible.

New unit tests in `__tests__/utils/app/settingsValidation.test.ts` cover validation and reserved-key error messaging.

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
