### PR TITLE
restore conversationsRef sync to prevent conversation wipe on new cre…

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -322,6 +322,10 @@ export const Chat = () => {
     selectedConversationRef.current = selectedConversation;
   }, [selectedConversation]);
 
+  useEffect(() => {
+    conversationsRef.current = conversations;
+  }, [conversations]);
+
   // Reset WebSocket state when conversation changes to prevent stale message display
   useEffect(() => {
     if (selectedConversation?.id) {


### PR DESCRIPTION
## Summary

Restores the `useEffect` sync for `conversationsRef` that was removed in PR #76, which introduced
a regression where creating a new conversation in WebSocket mode causes the previous conversation
to be deleted from the sidebar and WebSocket responses to not render.

## Root Cause

PR #76 (commit 25fe1f8) removed the `useEffect` that kept `conversationsRef` in sync with the
`conversations` state from context. It replaced this with manual write-throughs only inside
`handleSend` and `updateRefsAndDispatch`. This meant `conversationsRef` was never updated when
conversations changed from external operations like creating or deleting a conversation from
the sidebar.

When a user created a new conversation and sent a message:
1. `handleNewConversation` added the new conversation to `conversations` state
2. `conversationsRef` still held the old list (missing the new conversation)
3. `handleSend` mapped over the stale ref, produced a list without the new conversation
4. Dispatched that list, wiping the new conversation from state and sessionStorage
5. Incoming WebSocket responses were dropped because the target conversation no longer existed

## Note on PR #76

PR #76 claimed the `useEffect` sync caused a race condition where the ref would be overwritten
with stale state during re-renders, resulting in assistant response content intermittently
disappearing. However, the `useEffect` only fires when the `conversations` dependency actually
changes between renders, and the value it writes is the same value dispatched by the
write-through — so the described mechanism for data loss is unclear.

The issue (#75) that PR #76 was addressing lacked sufficient documentation to reproduce or
validate the reported behavior. The screenshots provided showed only the visual symptom (message
disappearing) without any evidence of the underlying state (console logs, ref values, render
traces) that would confirm the `useEffect` as the root cause. The existing test suite did not
catch this regression because the WebSocket tests re-implement logic locally rather than testing
the actual imported functions, providing coverage numbers without validating real behavior.

If the issue described in #75 resurfaces, it should be investigated with proper state-level
evidence and addressed without removing the ref sync, as it is essential for conversation
management outside of `handleSend` and `handleWebSocketMessage`.

## Fix

Re-added the `useEffect` to sync `conversationsRef` with `conversations`:

useEffect(() => {
  conversationsRef.current = conversations;
}, [conversations]);
