### PR TITLE
chore: pin shell-quote to ^1.8.4 via npm overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13606,9 +13606,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "babel-plugin-istanbul": "8.0.2",
     "jose": "^4.15.9",
     "mdast-util-to-hast": "13.2.1",
+    "shell-quote": "^1.8.4",
     "test-exclude": {
       "minimatch": "9.0.8"
     }


### PR DESCRIPTION
## Summary

- Adds `"shell-quote": "^1.8.4"` to the `overrides` block in `package.json`
- `shell-quote@1.8.3` is a transitive dependency introduced by `concurrently@8.2.2`; the override forces resolution to `1.8.4`
- `1.8.4` replaces per-character escaping in `quote()` with strict operator allowlist validation

## Test plan

- [ ] `npm ls shell-quote` shows `shell-quote@1.8.4`
- [ ] `npm run dev` starts normally